### PR TITLE
feat: support overriding accepted format

### DIFF
--- a/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/OgcApiFeaturesMediaType.java
+++ b/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/OgcApiFeaturesMediaType.java
@@ -26,8 +26,6 @@ import javax.ws.rs.core.MediaType;
 import java.util.HashMap;
 import java.util.Map;
 
-import static java.util.Collections.singletonMap;
-
 /**
  * Defines the mime types specified by
  * @author <a href="mailto:goltz@lat-lon.de">Lyn Goltz </a>
@@ -36,6 +34,11 @@ public final class OgcApiFeaturesMediaType {
 
     public static final String APPLICATION_OPENAPI = "application/vnd.oai.openapi+json;version=3.0";
     public static final MediaType APPLICATION_OPENAPI_TYPE = new MediaType("application", "vnd.oai.openapi+json;version=3.0");
+    
+    // Note: There is no registered media type yet, but this is the latest proposal
+    // See https://github.com/ietf-wg-httpapi/mediatypes/blob/main/draft-ietf-httpapi-yaml-mediatypes.md
+    public static final String APPLICATION_YAML = "application/yaml";
+    public static final MediaType APPLICATION_YAML_TYPE = new MediaType("application", "yaml");
 
     public static final String APPLICATION_GEOJSON = "application/geo+json";
     public static final MediaType APPLICATION_GEOJSON_TYPE = new MediaType("application", "geo+json");

--- a/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/filter/OverrideAcceptFilter.java
+++ b/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/filter/OverrideAcceptFilter.java
@@ -1,0 +1,119 @@
+package org.deegree.services.oaf.filter;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.PreMatching;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.UriInfo;
+import javax.ws.rs.ext.Provider;
+
+import org.deegree.services.oaf.OgcApiFeaturesMediaType;
+
+/**
+ * Filter that allows the Accept HTTP header to be overridden/extended by providing a query parameter or a file extension.
+ */
+@Provider
+@PreMatching
+public class OverrideAcceptFilter implements ContainerRequestFilter {
+	
+	/**
+	 * Name of query parameter that may specify a media type.
+	 */
+	public static final String QUERY_PARAM = "accept";
+	
+	/**
+	 * Map of supported extensions with their translation to a media type.
+	 */
+	private static final Map<String, String> ACCEPT_EXTENSIONS = Collections.unmodifiableMap(buildExtensionMap());
+	
+	private static Map<String, String> buildExtensionMap() {
+		Map<String, String> result = new HashMap<>();
+		
+		result.put("json", MediaType.APPLICATION_JSON);
+		result.put("yaml", OgcApiFeaturesMediaType.APPLICATION_YAML);
+		result.put("xml", MediaType.APPLICATION_XML);
+		result.put("html", MediaType.TEXT_HTML);
+		
+		return result;
+	}
+
+	@Override
+	public void filter(ContainerRequestContext requestContext) throws IOException {
+		// Priority 1: Check if query parameter overrides accepted format 
+		List<String> overrideTypes = requestContext.getUriInfo().getQueryParameters().get(QUERY_PARAM);
+		if (overrideTypes != null) {
+			// allow using "extensions" instead of mime types
+			overrideTypes = overrideTypes.stream().map(t -> {
+				String mapped = ACCEPT_EXTENSIONS.get(t);
+				if (mapped != null)
+					return mapped;
+				else
+					return t;
+			}).collect(Collectors.toList());
+		}
+		
+		if (overrideTypes == null || overrideTypes.isEmpty()) {
+			// Priority 2: Check if extension overrides accepted format (only specific extensions supported)
+			String path = requestContext.getUriInfo().getPath();
+			
+			Optional<String> overrideType = ACCEPT_EXTENSIONS.entrySet().stream()
+					.filter(e -> path.endsWith("." + e.getKey()))
+					.findAny()
+					.map(e -> {
+						stripRequestSuffix(requestContext, "." + e.getKey());
+						
+						return e.getValue();
+					});
+			
+			if (overrideType.isPresent()) {
+				overrideTypes = Collections.singletonList(overrideType.get());
+			}
+		}
+		
+		if (overrideTypes != null && !overrideTypes.isEmpty()) {
+			// if accepted type should be overridden prepend it to any existing accept header
+			MultivaluedMap<String, String> headers = requestContext.getHeaders();
+			List<String> newTypes = new ArrayList<>(overrideTypes);
+			List<String> orgAccept = headers.get(HttpHeaders.ACCEPT);
+			if (orgAccept != null) {
+				newTypes.addAll(orgAccept);
+			}
+			
+			// overwrite with combined header
+			// the original header is included to gracefully handle unsupported values or cases where the query parameter has a different use
+			headers.put(HttpHeaders.ACCEPT, Collections.singletonList(newTypes.stream().collect(Collectors.joining(", "))));
+		}
+	}
+
+	/**
+	 * Strip a suffix from the request URI.
+	 * 
+	 * @param requestContext the request context to modify
+	 * @param suffix the suffix to remove from the request URI
+	 */
+	private void stripRequestSuffix(ContainerRequestContext requestContext, String suffix) {
+		UriInfo org = requestContext.getUriInfo();
+		
+		String path = org.getRequestUri().getPath();
+		if (path.endsWith(suffix)) {
+			path = path.substring(0, path.length() - suffix.length());
+		}
+		
+		URI stripped = org.getRequestUriBuilder().replacePath(path).build();
+		
+		requestContext.setRequestUri(org.getBaseUri(), stripped);
+	}
+
+}

--- a/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/filter/UnknownParameterFilter.java
+++ b/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/filter/UnknownParameterFilter.java
@@ -82,6 +82,7 @@ public class UnknownParameterFilter implements ContainerRequestFilter {
     public void filter( ContainerRequestContext requestContext )
                     throws IOException {
         Set<String> expectedParams = collectExpectedParamsFromAnnotations();
+        expectedParams.add( OverrideAcceptFilter.QUERY_PARAM );
         addFilterParamsIfRequired( expectedParams );
         Set<String> requestParams = servletRequest.getParameterMap().keySet();
         requestParams.forEach( param -> {

--- a/deegree-ogcapi-features/src/main/resources/collection.html
+++ b/deegree-ogcapi-features/src/main/resources/collection.html
@@ -392,6 +392,9 @@ function retrieveBaseUrl() {
       if ( featuresRefWithoutQuery.endsWith("/") ) {
         featuresRefWithoutQuery = featuresRefWithoutQuery.substr(0, featuresRefWithoutQuery.length - 1);
       }
+      if ( featuresRefWithoutQuery.endsWith(".html") ) {
+        featuresRefWithoutQuery = featuresRefWithoutQuery.substr(0, featuresRefWithoutQuery.length - 5);
+      }
       return featuresRefWithoutQuery;
 }
 

--- a/deegree-ogcapi-features/src/main/resources/collections.html
+++ b/deegree-ogcapi-features/src/main/resources/collections.html
@@ -308,6 +308,9 @@ function retrieveBaseUrl() {
       if ( featuresRefWithoutQuery.endsWith("/") ) {
         featuresRefWithoutQuery = featuresRefWithoutQuery.substr(0, featuresRefWithoutQuery.length - 1);
       }
+      if ( featuresRefWithoutQuery.endsWith(".html") ) {
+        featuresRefWithoutQuery = featuresRefWithoutQuery.substr(0, featuresRefWithoutQuery.length - 5);
+      }
       return featuresRefWithoutQuery;
 }
 </script>

--- a/deegree-ogcapi-features/src/main/resources/conformance.html
+++ b/deegree-ogcapi-features/src/main/resources/conformance.html
@@ -210,6 +210,9 @@ function retrieveBaseUrl() {
       if ( featuresRefWithoutQuery.endsWith("/") ) {
         featuresRefWithoutQuery = featuresRefWithoutQuery.substr(0, featuresRefWithoutQuery.length - 1);
       }
+      if ( featuresRefWithoutQuery.endsWith(".html") ) {
+        featuresRefWithoutQuery = featuresRefWithoutQuery.substr(0, featuresRefWithoutQuery.length - 5);
+      }
       return featuresRefWithoutQuery;
 }
 </script>

--- a/deegree-ogcapi-features/src/main/resources/datasets.html
+++ b/deegree-ogcapi-features/src/main/resources/datasets.html
@@ -223,9 +223,12 @@ function retrieveBaseUrl() {
   if ( featuresRefWithoutQuery.indexOf('?') >= 0 ) {
     featuresRefWithoutQuery = featuresRefWithoutQuery.substr(0, featuresRefWithoutQuery.indexOf('?'));
   }
-      if ( featuresRefWithoutQuery.endsWith("/") ) {
-        featuresRefWithoutQuery = featuresRefWithoutQuery.substr(0, featuresRefWithoutQuery.length - 1);
-      }
+  if ( featuresRefWithoutQuery.endsWith("/") ) {
+    featuresRefWithoutQuery = featuresRefWithoutQuery.substr(0, featuresRefWithoutQuery.length - 1);
+  }
+  if ( featuresRefWithoutQuery.endsWith(".html") ) {
+    featuresRefWithoutQuery = featuresRefWithoutQuery.substr(0, featuresRefWithoutQuery.length - 5);
+  }
   return featuresRefWithoutQuery;
 }
 </script>

--- a/deegree-ogcapi-features/src/main/resources/feature.html
+++ b/deegree-ogcapi-features/src/main/resources/feature.html
@@ -560,6 +560,9 @@ function retrieveBaseUrl() {
       if ( featuresRefWithoutQuery.endsWith("/") ) {
         featuresRefWithoutQuery = featuresRefWithoutQuery.substr(0, featuresRefWithoutQuery.length - 1);
       }
+      if ( featuresRefWithoutQuery.endsWith(".html") ) {
+        featuresRefWithoutQuery = featuresRefWithoutQuery.substr(0, featuresRefWithoutQuery.length - 5);
+      }
       return featuresRefWithoutQuery;
 }
 </script>

--- a/deegree-ogcapi-features/src/main/resources/features.html
+++ b/deegree-ogcapi-features/src/main/resources/features.html
@@ -994,6 +994,9 @@ function retrieveBaseUrl() {
       if ( featuresRefWithoutQuery.endsWith("/") ) {
         featuresRefWithoutQuery = featuresRefWithoutQuery.substr(0, featuresRefWithoutQuery.length - 1);
       }
+      if ( featuresRefWithoutQuery.endsWith(".html") ) {
+        featuresRefWithoutQuery = featuresRefWithoutQuery.substr(0, featuresRefWithoutQuery.length - 5);
+      }
       return featuresRefWithoutQuery;
 }
 </script>

--- a/deegree-ogcapi-features/src/main/resources/landingpage.html
+++ b/deegree-ogcapi-features/src/main/resources/landingpage.html
@@ -276,9 +276,12 @@ function retrieveBaseUrl() {
   if ( featuresRefWithoutQuery.indexOf('?') >= 0 ) {
     featuresRefWithoutQuery = featuresRefWithoutQuery.substr(0, featuresRefWithoutQuery.indexOf('?'));
   }
-      if ( featuresRefWithoutQuery.endsWith("/") ) {
-        featuresRefWithoutQuery = featuresRefWithoutQuery.substr(0, featuresRefWithoutQuery.length - 1);
-      }
+  if ( featuresRefWithoutQuery.endsWith("/") ) {
+    featuresRefWithoutQuery = featuresRefWithoutQuery.substr(0, featuresRefWithoutQuery.length - 1);
+  }
+  if ( featuresRefWithoutQuery.endsWith(".html") ) {
+    featuresRefWithoutQuery = featuresRefWithoutQuery.substr(0, featuresRefWithoutQuery.length - 5);
+  }
   return featuresRefWithoutQuery;
 }
 </script>

--- a/deegree-ogcapi-features/src/test/java/org/deegree/services/oaf/filter/OverrideAcceptFilterTest.java
+++ b/deegree-ogcapi-features/src/test/java/org/deegree/services/oaf/filter/OverrideAcceptFilterTest.java
@@ -1,0 +1,115 @@
+/*-
+ * #%L
+ * deegree-ogcapi-features - OGC API Features (OAF) implementation - Querying and modifying of geospatial data objects
+ * %%
+ * Copyright (C) 2019 - 2020 lat/lon GmbH, info@lat-lon.de, www.lat-lon.de
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+package org.deegree.services.oaf.filter;
+
+import org.deegree.services.oaf.resource.FeatureCollection;
+import org.deegree.services.oaf.workspace.DataAccess;
+import org.deegree.services.oaf.workspace.DeegreeWorkspaceInitializer;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.test.JerseyTest;
+import org.glassfish.jersey.test.TestProperties;
+import org.junit.Test;
+
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Response;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static javax.ws.rs.core.MediaType.APPLICATION_XML;
+import static javax.ws.rs.core.MediaType.TEXT_HTML;
+import static org.deegree.services.oaf.TestData.mockDataAccess;
+import static org.deegree.services.oaf.TestData.mockWorkspaceInitializer;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Test overriding filter for overriding format via query parameter or extension.
+ */
+public class OverrideAcceptFilterTest extends JerseyTest {
+
+    @Override
+    protected Application configure() {
+        enable( TestProperties.LOG_TRAFFIC );
+        ResourceConfig resourceConfig = new ResourceConfig( FeatureCollection.class );
+        resourceConfig.register(OverrideAcceptFilter.class);
+        resourceConfig.register( new AbstractBinder() {
+            @Override
+            protected void configure() {
+                bind( mockDataAccess() ).to( DataAccess.class );
+                bind( mockWorkspaceInitializer() ).to( DeegreeWorkspaceInitializer.class );
+            }
+        } );
+        return resourceConfig;
+    }
+    
+    @Test
+    public void test_Header() {
+        Response response = target( "/datasets/oaf/collections/test" ).request( APPLICATION_JSON_TYPE ).get();
+        assertThat( response.getStatus(), is( 200 ) );
+        assertThat( response.getHeaderString(HttpHeaders.CONTENT_TYPE), is( APPLICATION_JSON ) );
+    }
+    
+    @Test
+    public void test_Extension() {
+        Response response = target( "/datasets/oaf/collections/test.xml" ).request().get();
+        assertThat( response.getStatus(), is( 200 ) );
+        assertThat( response.getHeaderString(HttpHeaders.CONTENT_TYPE), is( APPLICATION_XML ) );
+    }
+    
+    @Test
+    public void test_ExtensionFallback() {
+        Response response = target( "/datasets/oaf/collections/test.xkcd" ).request( APPLICATION_JSON_TYPE ).get();
+        assertThat( response.getStatus(), is( 200 ) );
+        assertThat( response.getHeaderString(HttpHeaders.CONTENT_TYPE), is( APPLICATION_JSON ) );
+    }
+    
+    @Test
+    public void test_QueryParam() {
+        Response response = target( "/datasets/oaf/collections/test" ).queryParam("accept", "xml").request().get();
+        assertThat( response.getStatus(), is( 200 ) );
+        assertThat( response.getHeaderString(HttpHeaders.CONTENT_TYPE), is( APPLICATION_XML ) );
+    }
+    
+    @Test
+    public void test_QueryParamMediaType() {
+        Response response = target( "/datasets/oaf/collections/test" ).queryParam("accept", APPLICATION_XML).request().get();
+        assertThat( response.getStatus(), is( 200 ) );
+        assertThat( response.getHeaderString(HttpHeaders.CONTENT_TYPE), is( APPLICATION_XML ) );
+    }
+
+    @Test
+    public void test_Priorities() {
+        Response response = target( "/datasets/oaf/collections/test.html" ).queryParam("accept", "xml").request( APPLICATION_JSON_TYPE ).get();
+        assertThat( response.getStatus(), is( 200 ) );
+        assertThat( response.getHeaderString(HttpHeaders.CONTENT_TYPE), is( APPLICATION_XML ) );
+    }
+    
+    @Test
+    public void test_PriorityExtension() {
+        Response response = target( "/datasets/oaf/collections/test.html" ).request( APPLICATION_JSON_TYPE ).get();
+        assertThat( response.getStatus(), is( 200 ) );
+        assertThat( response.getHeaderString(HttpHeaders.CONTENT_TYPE), is( TEXT_HTML ) );
+    }
+
+}


### PR DESCRIPTION
Support overriding accepted format for a request by specifying a query parameter or adding an extension to the request URL:

- if a query parameter "accept" is provided, its value is looked up in the supported list of extension, if not present it is directly used as media type
- otherwise, if the request URL ends on `.` plus a supported extension, the media type associated to the extension is used as media type
- any values provided via the Accept header are appended