### PR TITLE
feat: serve OpenAPI description also as YAML 

### DIFF
--- a/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/OgcApiFeaturesMediaType.java
+++ b/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/OgcApiFeaturesMediaType.java
@@ -35,6 +35,9 @@ public final class OgcApiFeaturesMediaType {
     public static final String APPLICATION_OPENAPI = "application/vnd.oai.openapi+json;version=3.0";
     public static final MediaType APPLICATION_OPENAPI_TYPE = new MediaType("application", "vnd.oai.openapi+json;version=3.0");
     
+    public static final String APPLICATION_OPENAPI_YAML = "application/vnd.oai.openapi+yaml;version=3.0";
+    public static final MediaType APPLICATION_OPENAPI_YAML_TYPE = new MediaType("application", "vnd.oai.openapi+yaml;version=3.0");
+    
     // Note: There is no registered media type yet, but this is the latest proposal
     // See https://github.com/ietf-wg-httpapi/mediatypes/blob/main/draft-ietf-httpapi-yaml-mediatypes.md
     public static final String APPLICATION_YAML = "application/yaml";

--- a/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/resource/OpenApi.java
+++ b/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/resource/OpenApi.java
@@ -22,6 +22,7 @@
 package org.deegree.services.oaf.resource;
 
 import io.swagger.v3.core.util.Json;
+import io.swagger.v3.core.util.Yaml;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.models.OpenAPI;
@@ -46,6 +47,8 @@ import java.io.FileNotFoundException;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.MediaType.TEXT_HTML;
 import static org.deegree.services.oaf.OgcApiFeaturesMediaType.APPLICATION_OPENAPI;
+import static org.deegree.services.oaf.OgcApiFeaturesMediaType.APPLICATION_OPENAPI_YAML;
+import static org.deegree.services.oaf.OgcApiFeaturesMediaType.APPLICATION_YAML;
 import static org.slf4j.LoggerFactory.getLogger;
 
 /**
@@ -72,14 +75,40 @@ public class OpenApi {
                     @PathParam("datasetId")
                                     String datasetId )
                     throws Exception {
-        OpenAPI openApi = this.openApiCreator.createOpenApi( headers, datasetId );
+        return respondWithOpenApi( headers, datasetId, true );
+    }
+    
+    @GET
+    @Produces({ APPLICATION_OPENAPI_YAML, APPLICATION_YAML })
+    @Operation(operationId = "openApi", summary = "api documentation", description = "api documentation")
+    @Tag(name = "Capabilities")
+    public Response getOpenApiOpenApiYaml(
+                    @Context HttpHeaders headers,
+                    @Context UriInfo uriInfo,
+                    @PathParam("datasetId")
+                                    String datasetId )
+                    throws Exception {
+        return respondWithOpenApi( headers, datasetId, false );
+    }
+
+    private Response respondWithOpenApi(HttpHeaders headers, String datasetId, boolean json) throws Exception {
+    	OpenAPI openApi = this.openApiCreator.createOpenApi( headers, datasetId );
 
         if ( openApi == null )
             return Response.status( 404 ).build();
-        return Response.status( Response.Status.OK ).entity( Json.mapper().writeValueAsString( openApi ) ).build();
-    }
+        
+        String rendered;
+        if (json) {
+        	rendered = Json.mapper().writeValueAsString( openApi );
+        }
+        else {
+        	rendered = Yaml.mapper().writeValueAsString( openApi );
+        }
+        
+        return Response.status( Response.Status.OK ).entity( rendered ).build();
+	}
 
-    @GET
+	@GET
     @Produces({ TEXT_HTML })
     @Operation(hidden = true)
     public Response getOpenApiHtml() {

--- a/deegree-ogcapi-features/src/test/java/org/deegree/services/oaf/resource/OpenApiTest.java
+++ b/deegree-ogcapi-features/src/test/java/org/deegree/services/oaf/resource/OpenApiTest.java
@@ -39,6 +39,7 @@ import org.junit.rules.TemporaryFolder;
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletContext;
 import javax.ws.rs.core.Application;
+import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
@@ -104,6 +105,12 @@ public class OpenApiTest extends JerseyTest {
     @Test public void test_OpenApiHtmlShouldBeAvailable() {
         int status = target( "/datasets/oaf/api" ).request( MediaType.TEXT_HTML ).get().getStatus();
         assertThat( status, is( 200 ) );
+    }
+    
+    @Test public void test_OpenApiYamlShouldBeAvailable() {
+        Response response = target( "/datasets/oaf/api" ).request( OgcApiFeaturesMediaType.APPLICATION_YAML_TYPE ).get();
+        assertThat( response.getStatus(), is( 200 ) );
+        assertThat( response.getHeaderString( HttpHeaders.CONTENT_TYPE ), is( OgcApiFeaturesMediaType.APPLICATION_YAML ) );
     }
 
     @Test public void test_OpenApiCssShouldReturnCorrectMimeType() {


### PR DESCRIPTION
Support serving the OpenAPI description as YAML in addition to the
already supported JSON format.

Depends on https://github.com/wetransform-os/deegree-ogcapi/pull/5 due to the dependency on the YAML media type defnition.