### PR TITLE
fix: use storage CRS code from list of supported CRS

### DIFF
--- a/deegree-ogcapi-config-htmlview/pom.xml
+++ b/deegree-ogcapi-config-htmlview/pom.xml
@@ -22,11 +22,11 @@
 
   <dependencies>
     <dependency>
-      <groupId>${deegree-group}</groupId>
+      <groupId>org.deegree</groupId>
       <artifactId>deegree-core-commons</artifactId>
     </dependency>
     <dependency>
-      <groupId>${deegree-group}</groupId>
+      <groupId>org.deegree</groupId>
       <artifactId>deegree-core-workspace</artifactId>
     </dependency>
     <dependency>

--- a/deegree-ogcapi-config/pom.xml
+++ b/deegree-ogcapi-config/pom.xml
@@ -12,27 +12,27 @@
 
   <dependencies>
     <dependency>
-      <groupId>${deegree-group}</groupId>
+      <groupId>org.deegree</groupId>
       <artifactId>deegree-core-commons</artifactId>
     </dependency>
     <dependency>
-      <groupId>${deegree-group}</groupId>
+      <groupId>org.deegree</groupId>
       <artifactId>deegree-core-base</artifactId>
     </dependency>
     <dependency>
-      <groupId>${deegree-group}</groupId>
+      <groupId>org.deegree</groupId>
       <artifactId>deegree-services-config</artifactId>
     </dependency>
     <dependency>
-      <groupId>${deegree-group}</groupId>
+      <groupId>org.deegree</groupId>
       <artifactId>deegree-services-commons</artifactId>
     </dependency>
     <dependency>
-      <groupId>${deegree-group}</groupId>
+      <groupId>org.deegree</groupId>
       <artifactId>deegree-featurestore-commons</artifactId>
     </dependency>
     <dependency>
-      <groupId>${deegree-group}</groupId>
+      <groupId>org.deegree</groupId>
       <artifactId>deegree-core-workspace</artifactId>
     </dependency>
     <dependency>

--- a/deegree-ogcapi-datasets/pom.xml
+++ b/deegree-ogcapi-datasets/pom.xml
@@ -22,11 +22,11 @@
 
   <dependencies>
     <dependency>
-      <groupId>${deegree-group}</groupId>
+      <groupId>org.deegree</groupId>
       <artifactId>deegree-core-commons</artifactId>
     </dependency>
     <dependency>
-      <groupId>${deegree-group}</groupId>
+      <groupId>org.deegree</groupId>
       <artifactId>deegree-core-workspace</artifactId>
     </dependency>
     <dependency>

--- a/deegree-ogcapi-features/pom.xml
+++ b/deegree-ogcapi-features/pom.xml
@@ -49,31 +49,31 @@
     </dependency>
     <!-- deegree-core -->
     <dependency>
-      <groupId>${deegree-group}</groupId>
+      <groupId>org.deegree</groupId>
       <artifactId>deegree-core-geometry</artifactId>
     </dependency>
     <dependency>
-      <groupId>${deegree-group}</groupId>
+      <groupId>org.deegree</groupId>
       <artifactId>deegree-core-base</artifactId>
     </dependency>
     <dependency>
-      <groupId>${deegree-group}</groupId>
+      <groupId>org.deegree</groupId>
       <artifactId>deegree-featurestore-commons</artifactId>
     </dependency>
     <dependency>
-      <groupId>${deegree-group}</groupId>
+      <groupId>org.deegree</groupId>
       <artifactId>deegree-core-cs</artifactId>
     </dependency>
     <dependency>
-      <groupId>${deegree-group}</groupId>
+      <groupId>org.deegree</groupId>
       <artifactId>deegree-core-workspace</artifactId>
     </dependency>
     <dependency>
-      <groupId>${deegree-group}</groupId>
+      <groupId>org.deegree</groupId>
       <artifactId>deegree-core-commons</artifactId>
     </dependency>
     <dependency>
-      <groupId>${deegree-group}</groupId>
+      <groupId>org.deegree</groupId>
       <artifactId>deegree-services-commons</artifactId>
       <exclusions>
         <exclusion>
@@ -87,7 +87,7 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>${deegree-group}</groupId>
+      <groupId>org.deegree</groupId>
       <artifactId>deegree-protocol-wfs</artifactId>
     </dependency>
     <dependency>

--- a/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/OafResource.java
+++ b/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/OafResource.java
@@ -63,6 +63,7 @@ import org.slf4j.Logger;
 
 import javax.xml.namespace.QName;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -284,7 +285,7 @@ public class OafResource implements Resource {
         List<MetadataUrl> metadataUrls = datasetMetadata != null && !datasetMetadata.getMetadataUrls().isEmpty() ?
                                          datasetMetadata.getMetadataUrls() :
                                          Collections.emptyList();
-        String storageCrs = featureStore.getStorageCrs() != null ? featureStore.getStorageCrs().getName() : null;
+        String[] storageCrsCodes = featureStore.getStorageCrs() != null ? featureStore.getStorageCrs().getOrignalCodeStrings() : null;
         return new FeatureTypeMetadata( name )
                         .dateTimeProperty( dateTimeProperty )
                         .extent( extent )
@@ -293,7 +294,7 @@ public class OafResource implements Resource {
                         .metadataUrls( metadataUrls )
                         .filterProperties( filterProperties )
                         .featureType( featureType )
-                        .storageCrs( storageCrs );
+                        .storageCrsCodes( storageCrsCodes != null ? Arrays.asList( storageCrsCodes ) : null );
     }
 
     private List<FilterProperty> parseFilterProperties( FeatureType featureType ) {

--- a/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/workspace/configuration/FeatureTypeMetadata.java
+++ b/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/workspace/configuration/FeatureTypeMetadata.java
@@ -49,7 +49,7 @@ public class FeatureTypeMetadata {
 
     private FeatureType featureType;
 
-    private String storageCrs;
+    private List<String> storageCrsCodes;
 
     public FeatureTypeMetadata( QName featureTypeName ) {
         this.name = featureTypeName;
@@ -91,8 +91,8 @@ public class FeatureTypeMetadata {
         return this;
     }
 
-    public FeatureTypeMetadata storageCrs( String storageCrs ) {
-        this.storageCrs = storageCrs;
+    public FeatureTypeMetadata storageCrsCodes( List<String> storageCrsCodes ) {
+        this.storageCrsCodes = storageCrsCodes;
         return this;
     }
 
@@ -128,7 +128,7 @@ public class FeatureTypeMetadata {
         return featureType;
     }
 
-    public String getStorageCrs() {
-        return storageCrs;
+    public List<String> getStorageCrsCodes() {
+        return storageCrsCodes;
     }
 }

--- a/deegree-ogcapi-features/src/test/java/org/deegree/services/oaf/workspace/DeegreeDataAccessTest.java
+++ b/deegree-ogcapi-features/src/test/java/org/deegree/services/oaf/workspace/DeegreeDataAccessTest.java
@@ -1,0 +1,72 @@
+/*-
+ * #%L
+ * deegree-ogcapi-features - OGC API Features (OAF) implementation - Querying and modifying of geospatial data objects
+ * %%
+ * Copyright (C) 2019 - 2020 lat/lon GmbH, info@lat-lon.de, www.lat-lon.de
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+package org.deegree.services.oaf.workspace;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.deegree.cs.coordinatesystems.ICRS;
+import org.deegree.cs.exceptions.UnknownCRSException;
+import org.deegree.cs.persistence.CRSManager;
+import org.junit.Test;
+
+public class DeegreeDataAccessTest {
+	
+	@Test
+	public void test_selectCrsCode_ETRS89() throws UnknownCRSException {
+		String lookupCode = "http://www.opengis.net/def/crs/EPSG/0/4258";
+		String code = selectCode( lookupCode, Arrays.asList( lookupCode ) );
+		assertThat( code, is( lookupCode ));
+	}
+	
+	@Test
+	public void test_selectCrsCode_WGS84() throws UnknownCRSException {
+		String lookupCode = "http://www.opengis.net/def/crs/EPSG/0/4326";
+		String code = selectCode( lookupCode, Arrays.asList( lookupCode ) );
+		assertThat( code, is( lookupCode ) );
+	}
+	
+	@Test
+	public void test_selectCrsCode_ETRS89_AlternateCode() throws UnknownCRSException {
+		String lookupCode = "urn:ogc:def:crs:EPSG::4258";
+		String allowedCode = "http://www.opengis.net/def/crs/EPSG/0/4258";
+		String code = selectCode( lookupCode, Arrays.asList( allowedCode ) );
+		assertThat( code, is( allowedCode ) );
+	}
+	
+	@Test
+	public void test_selectCrsCode_NoMatch() throws UnknownCRSException {
+		String lookupCode = "http://www.opengis.net/def/crs/EPSG/0/4326";
+		ICRS crs = CRSManager.lookup( lookupCode );
+		String code = selectCode( lookupCode, Arrays.asList( "EPSG:12345" ) );
+		assertThat( code, is( crs.getCode().getOriginal() ));
+	}
+	
+	private String selectCode( String crsCode, List<String> supportedCodes ) throws UnknownCRSException {
+		ICRS crs = CRSManager.lookup( crsCode );
+		return DeegreeDataAccess.selectCrsCode( Arrays.asList( crs.getOrignalCodeStrings() ), supportedCodes );
+	}
+
+}

--- a/deegree-ogcapi-webapp/deegree-ogcapi-webapp-oracle/pom.xml
+++ b/deegree-ogcapi-webapp/deegree-ogcapi-webapp-oracle/pom.xml
@@ -34,17 +34,17 @@
 
   <dependencies>
     <dependency>
-      <groupId>${deegree-group}</groupId>
+      <groupId>org.deegree</groupId>
       <artifactId>deegree-sqldialect-oracle</artifactId>
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <groupId>${deegree-group}</groupId>
+      <groupId>org.deegree</groupId>
       <artifactId>deegree-featurestore-simplesql</artifactId>
       <scope>runtime</scope>
       <exclusions>
         <exclusion>
-          <groupId>${deegree-group}</groupId>
+          <groupId>org.deegree</groupId>
           <artifactId>deegree-sqldialect-postgis</artifactId>
         </exclusion>
       </exclusions>

--- a/deegree-ogcapi-webapp/deegree-ogcapi-webapp-postgres/pom.xml
+++ b/deegree-ogcapi-webapp/deegree-ogcapi-webapp-postgres/pom.xml
@@ -34,7 +34,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>${deegree-group}</groupId>
+      <groupId>org.deegree</groupId>
       <artifactId>deegree-sqldialect-postgis</artifactId>
       <scope>runtime</scope>
     </dependency>

--- a/deegree-ogcapi-webapp/pom.xml
+++ b/deegree-ogcapi-webapp/pom.xml
@@ -186,27 +186,27 @@
     </dependency>
     <!-- deegree-core -->
     <dependency>
-      <groupId>${deegree-group}</groupId>
+      <groupId>org.deegree</groupId>
       <artifactId>deegree-featurestore-sql</artifactId>
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <groupId>${deegree-group}</groupId>
+      <groupId>org.deegree</groupId>
       <artifactId>deegree-featurestore-simplesql</artifactId>
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <groupId>${deegree-group}</groupId>
+      <groupId>org.deegree</groupId>
       <artifactId>deegree-featurestore-memory</artifactId>
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <groupId>${deegree-group}</groupId>
+      <groupId>org.deegree</groupId>
       <artifactId>deegree-featurestore-shape</artifactId>
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <groupId>${deegree-group}</groupId>
+      <groupId>org.deegree</groupId>
       <artifactId>deegree-connectionprovider-datasource</artifactId>
       <scope>runtime</scope>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -39,16 +39,6 @@
         <enabled>true</enabled>
       </snapshots>
     </repository>
-    <repository>
-      <id>jitpack</id>
-      <url>https://jitpack.io</url>
-      <releases>
-        <updatePolicy>never</updatePolicy>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
     <!--
     <repository>
       <id>deegree-repo</id>
@@ -513,32 +503,32 @@
     <dependencies>
       <!-- deegree-core -->
       <dependency>
-        <groupId>${deegree-group}</groupId>
+        <groupId>org.deegree</groupId>
         <artifactId>deegree-featurestore-commons</artifactId>
         <version>${deegree-version}</version>
       </dependency>
       <dependency>
-        <groupId>${deegree-group}</groupId>
+        <groupId>org.deegree</groupId>
         <artifactId>deegree-featurestore-sql</artifactId>
         <version>${deegree-version}</version>
       </dependency>
       <dependency>
-        <groupId>${deegree-group}</groupId>
+        <groupId>org.deegree</groupId>
         <artifactId>deegree-featurestore-simplesql</artifactId>
         <version>${deegree-version}</version>
       </dependency>
       <dependency>
-        <groupId>${deegree-group}</groupId>
+        <groupId>org.deegree</groupId>
         <artifactId>deegree-featurestore-memory</artifactId>
         <version>${deegree-version}</version>
       </dependency>
       <dependency>
-        <groupId>${deegree-group}</groupId>
+        <groupId>org.deegree</groupId>
         <artifactId>deegree-featurestore-shape</artifactId>
         <version>${deegree-version}</version>
       </dependency>
       <dependency>
-        <groupId>${deegree-group}</groupId>
+        <groupId>org.deegree</groupId>
         <artifactId>deegree-services-commons</artifactId>
         <version>${deegree-version}</version>
         <scope>compile</scope>
@@ -554,27 +544,27 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>${deegree-group}</groupId>
+        <groupId>org.deegree</groupId>
         <artifactId>deegree-sqldialect-postgis</artifactId>
         <version>${deegree-version}</version>
       </dependency>
       <dependency>
-        <groupId>${deegree-group}</groupId>
+        <groupId>org.deegree</groupId>
         <artifactId>deegree-sqldialect-oracle</artifactId>
         <version>${deegree-version}</version>
       </dependency>
       <dependency>
-        <groupId>${deegree-group}</groupId>
+        <groupId>org.deegree</groupId>
         <artifactId>deegree-connectionprovider-datasource</artifactId>
         <version>${deegree-version}</version>
       </dependency>
       <dependency>
-        <groupId>${deegree-group}</groupId>
+        <groupId>org.deegree</groupId>
         <artifactId>deegree-core-base</artifactId>
         <version>${deegree-version}</version>
       </dependency>
       <dependency>
-        <groupId>${deegree-group}</groupId>
+        <groupId>org.deegree</groupId>
         <artifactId>deegree-core-commons</artifactId>
         <version>${deegree-version}</version>
         <exclusions>
@@ -585,27 +575,27 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>${deegree-group}</groupId>
+        <groupId>org.deegree</groupId>
         <artifactId>deegree-core-geometry</artifactId>
         <version>${deegree-version}</version>
       </dependency>
       <dependency>
-        <groupId>${deegree-group}</groupId>
+        <groupId>org.deegree</groupId>
         <artifactId>deegree-core-workspace</artifactId>
         <version>${deegree-version}</version>
       </dependency>
       <dependency>
-        <groupId>${deegree-group}</groupId>
+        <groupId>org.deegree</groupId>
         <artifactId>deegree-core-cs</artifactId>
         <version>${deegree-version}</version>
       </dependency>
       <dependency>
-        <groupId>${deegree-group}</groupId>
+        <groupId>org.deegree</groupId>
         <artifactId>deegree-services-config</artifactId>
         <version>${deegree-version}</version>
       </dependency>
       <dependency>
-        <groupId>${deegree-group}</groupId>
+        <groupId>org.deegree</groupId>
         <artifactId>deegree-protocol-wfs</artifactId>
         <version>${deegree-version}</version>
       </dependency>
@@ -911,17 +901,6 @@
         <artifactId>gson</artifactId>
         <version>2.8.9</version>
       </dependency>
-      <!-- jitpack issue workaround - it seems jitpack changes org.deegree dependencies to wrong versions -->
-      <dependency>
-        <groupId>org.deegree</groupId>
-        <artifactId>deegree-ogcschemas</artifactId>
-        <version>20210817</version> <!-- jitpack for some reasons produces dependency to 3.5.0-SNAPSHOT version -->
-      </dependency>
-      <dependency>
-        <groupId>org.deegree</groupId>
-        <artifactId>junidecode</artifactId>
-        <version>0.2</version> <!-- jitpack for some reasons produces dependency to 3.5.0-SNAPSHOT version -->
-      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -934,10 +913,7 @@
     <swagger-version>2.1.13</swagger-version>
     <swagger-ui-version>3.52.5</swagger-ui-version>
     <jackson-version>2.14.1</jackson-version>
-    <!-- <deegree-group>org.deegree</deegree-group> -->
-    <deegree-group>com.github.wetransform-os.deegree3</deegree-group>
-    <!-- <deegree-version>3.5.0-SNAPSHOT</deegree-version> -->
-    <deegree-version>ogcapi-7240-SNAPSHOT</deegree-version>
+    <deegree-version>3.5.0-SNAPSHOT</deegree-version>
     <slf4j.version>1.7.36</slf4j.version>
     <log4j.version>2.17.2</log4j.version>
   </properties>


### PR DESCRIPTION
...instead of the CRS name.
If no match can be found for the storage CRS codes in the list of supported CRS, the first of the storage CRS codes is used.

This is done to if possible fulfill the requirement in the specification of OGC API Features Part 2, that the storage CRS shall be one of the identifiers of the supported CRS.