### PR TITLE
refactor: support additional query parameter for overriding format

### DIFF
--- a/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/filter/UnknownParameterFilter.java
+++ b/deegree-ogcapi-features/src/main/java/org/deegree/services/oaf/filter/UnknownParameterFilter.java
@@ -82,7 +82,9 @@ public class UnknownParameterFilter implements ContainerRequestFilter {
     public void filter( ContainerRequestContext requestContext )
                     throws IOException {
         Set<String> expectedParams = collectExpectedParamsFromAnnotations();
-        expectedParams.add( OverrideAcceptFilter.QUERY_PARAM );
+        for (String param : OverrideAcceptFilter.QUERY_PARAMS) {
+        	expectedParams.add( param );
+        }
         addFilterParamsIfRequired( expectedParams );
         Set<String> requestParams = servletRequest.getParameterMap().keySet();
         requestParams.forEach( param -> {

--- a/deegree-ogcapi-features/src/test/java/org/deegree/services/oaf/filter/OverrideAcceptFilterTest.java
+++ b/deegree-ogcapi-features/src/test/java/org/deegree/services/oaf/filter/OverrideAcceptFilterTest.java
@@ -85,17 +85,31 @@ public class OverrideAcceptFilterTest extends JerseyTest {
     }
     
     @Test
-    public void test_QueryParam() {
+    public void test_QueryParam_Accept() {
         Response response = target( "/datasets/oaf/collections/test" ).queryParam("accept", "xml").request().get();
         assertThat( response.getStatus(), is( 200 ) );
         assertThat( response.getHeaderString(HttpHeaders.CONTENT_TYPE), is( APPLICATION_XML ) );
     }
     
     @Test
-    public void test_QueryParamMediaType() {
+    public void test_QueryParamMediaType_Accept() {
         Response response = target( "/datasets/oaf/collections/test" ).queryParam("accept", APPLICATION_XML).request().get();
         assertThat( response.getStatus(), is( 200 ) );
         assertThat( response.getHeaderString(HttpHeaders.CONTENT_TYPE), is( APPLICATION_XML ) );
+    }
+    
+    @Test
+    public void test_QueryParam_f_xml() {
+        Response response = target( "/datasets/oaf/collections/test" ).queryParam("f", "xml").request().get();
+        assertThat( response.getStatus(), is( 200 ) );
+        assertThat( response.getHeaderString(HttpHeaders.CONTENT_TYPE), is( APPLICATION_XML ) );
+    }
+    
+    @Test
+    public void test_QueryParam_f_json() {
+        Response response = target( "/datasets/oaf/collections/test" ).queryParam("f", "json").request().get();
+        assertThat( response.getStatus(), is( 200 ) );
+        assertThat( response.getHeaderString(HttpHeaders.CONTENT_TYPE), is( APPLICATION_JSON ) );
     }
 
     @Test


### PR DESCRIPTION
Also support `f` as query parameter for overriding the format, so it is consistent with resources where that is already used. The specific implementation of handling the `f` query parameter takes precedence over the generic override.